### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/src/services/generate.service.ts
+++ b/src/services/generate.service.ts
@@ -307,8 +307,8 @@ export async function generateArtifacts(input: FFInput, options?: GenerateOption
     return `${fmt(lat, true)}, ${fmt(lon, false)}`
   }
   function cssUrlSingleQuoted(path: string): string {
-    // Conserver le chemin tel quel pour correspondre aux clés du manifest; échapper uniquement les apostrophes
-    return String(path).replace(/'/g, "\\'")
+    // Conserver le chemin tel quel pour correspondre aux clés du manifest; échapper les apostrophes ET les backslashes
+    return String(path).replace(/\\/g, "\\\\").replace(/'/g, "\\'");
   }
   function cssUrlValue(urlStr: string): string {
     // Pour data: on ne met pas de quotes; sinon, quotes simples


### PR DESCRIPTION
Potential fix for [https://github.com/stalina/travel-book-js/security/code-scanning/1](https://github.com/stalina/travel-book-js/security/code-scanning/1)

To fix the problem, we should escape *all* backslashes in the input string before escaping other metacharacters such as single quotes. The standard approach is to always replace backslashes (`\`) with double backslashes (`\\`), then single quotes (`'`) with escaped single quotes (`\'`). This way, any pre-existing backslashes are preserved and don't interfere with subsequent escaping. The fix applies only to the `cssUrlSingleQuoted` function in `src/services/generate.service.ts`, specifically to line 311. There is no need for additional imports, as this logic can be written using standard JS string methods.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
